### PR TITLE
Fix for macOS with wgpu v0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 shaderc = "0.7.2"
-wgpu = "0.9.0"
+wgpu = {version = "0.9", features = ["cross"]}
 
 [dev-dependencies]
 winit = "0.24.0"


### PR DESCRIPTION
Hello. 
I have tried the last couple of days to get this running on macOS. 
I have hit a lot of different errors (none of which seems to be due to this project).
I have filed an issue with naga to fix one of the issues: https://github.com/gfx-rs/naga/issues/1275 but in the meantime I have enabled the cross feature for the wgpu crate. This allows the shader translation to be created using a more stable crate "spirv-cross" that are able to generate the correct .metal shader for macOS.

In one of my branches I have also worked on updating the wgpu dependency to v0.10 (it was released yesterday), but since the cross feature is not included in that release I have not created a pull-request for that. It does work on Windows machines.

Hopefully this is a fine change, and that you are able to release a new version to crates.io, so I can depend on that instead of a local copy .

Thank you and have a nice day 😄 .