### PR TITLE
Update wgpu to 22.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 include = ["README.md", "LICENSE", "/src", "/third_party"]
 
 [dependencies]
-wgpu = { version = "0.20", features = ["glsl"] }
+wgpu = { version = "22.0.0", features = ["glsl"] }
 
 [dev-dependencies]
 winit = "0.29"

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -73,6 +73,7 @@ fn main() {
         depth_stencil: None,
         multisample: wgpu::MultisampleState::default(),
         multiview: None,
+        cache: None
     });
 
     // Main loop

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,6 +306,7 @@ impl Pipelines {
             multisample: Default::default(),
             depth_stencil: None,
             multiview: None,
+            cache: None
         });
 
         let blend_weight_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
@@ -349,6 +350,7 @@ impl Pipelines {
             multisample: Default::default(),
             depth_stencil: None,
             multiview: None,
+            cache: None
         });
 
         let neighborhood_blending_layout =
@@ -394,6 +396,7 @@ impl Pipelines {
                 multisample: Default::default(),
                 depth_stencil: None,
                 multiview: None,
+                cache: None
             });
 
         Self {


### PR DESCRIPTION
I bumped wgpu version in Cargo.toml to [22.0.0](https://github.com/gfx-rs/wgpu/releases/tag/v22.0.0) and added the `cache` field required for the `RenderPipelineDescriptor` struct, setting it to `None`.